### PR TITLE
cast `mrb_int` to `int` before applying sprintf "%d"

### DIFF
--- a/src/errno.c
+++ b/src/errno.c
@@ -43,7 +43,7 @@ mrb_sce_init(mrb_state *mrb, mrb_value self)
     } else {
       mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "errno"), mrb_fixnum_value(n));
       str = mrb_str_new_cstr(mrb, "Unknown error: ");
-      snprintf(buf, sizeof(buf), "%d", n);
+      snprintf(buf, sizeof(buf), "%d", (int)n);
       mrb_str_cat2(mrb, str, buf);
     }
   } else {


### PR DESCRIPTION
Quick fix to get the module working when `MRB_INT64` is set.

FWIW you might want to address the issue by calling `mrb_fixnum_to_str`.  Also, I have send a PR that adds printf-compatible format specifiers to mruby https://github.com/mruby/mruby/pull/3070; waiting for it to get resolved and then using the added solution might also be an option (though doing so might cause compatibility issues with prior versions of mruby).
